### PR TITLE
Add Mac optimization tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,29 @@ You can install ComfyUI in Apple Mac silicon (M1 or M2) with any recent macOS ve
 
 > **Note**: Remember to add your models, VAE, LoRAs etc. to the corresponding Comfy folders, as discussed in [ComfyUI manual installation](#manual-install-windows-linux).
 
+#### Apple Mac Tips
+
+ComfyUI relies on PyTorch's MPS backend when running on Apple silicon. On
+machines with limited unified memory such as a 32&nbsp;GB MacBook, you may need to
+reduce the memory footprint of the application:
+
+
+You can automate these tweaks with the `--mps-memory-optimizations` flag, which
+enables the recommended options and sets `PYTORCH_ENABLE_MPS_FALLBACK=1` for you.
+
+1. Start ComfyUI with the `--lowvram` flag to split the UNet and lower memory
+   usage.
+2. Set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to allow PyTorch
+   to fall back to CPU implementations for operators not available on MPS.
+3. Use `--cache-none` if memory pressure persists, trading execution speed for a
+   smaller memory footprint.
+
+Example:
+
+```bash
+python main.py --mps-memory-optimizations
+```
+
 #### DirectML (AMD Cards on Windows)
 
 This is very badly supported and is not recommended. There are some unofficial builds of pytorch ROCm on windows that exist that will give you a much better experience than this. This readme will be updated once official pytorch ROCm builds for windows come out.

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -131,6 +131,12 @@ parser.add_argument("--reserve-vram", type=float, default=None, help="Set the am
 
 parser.add_argument("--async-offload", action="store_true", help="Use async weight offloading.")
 
+parser.add_argument(
+    "--mps-memory-optimizations",
+    action="store_true",
+    help="On Apple MPS devices automatically enable low memory flags.",
+)
+
 parser.add_argument("--default-hashing-function", type=str, choices=['md5', 'sha1', 'sha256', 'sha512'], default='sha256', help="Allows you to choose the hash function to use for duplicate filename / contents comparison. Default is sha256.")
 
 parser.add_argument("--disable-smart-memory", action="store_true", help="Force ComfyUI to agressively offload to regular ram instead of keeping models in vram when it can.")
@@ -221,6 +227,13 @@ if args.disable_auto_launch:
 
 if args.force_fp16:
     args.fp16_unet = True
+
+if args.mps_memory_optimizations and torch.backends.mps.is_available():
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+    if not any((args.lowvram, args.highvram, args.novram, args.normalvram)):
+        args.lowvram = True
+    if not (args.cache_lru or args.cache_classic or args.cache_none):
+        args.cache_none = True
 
 
 # '--fast' is not provided, use an empty set

--- a/main.py
+++ b/main.py
@@ -159,6 +159,8 @@ def prompt_worker(q, server_instance):
     last_gc_collect = 0
     need_gc = False
     gc_collect_interval = 10.0
+    if args.mps_memory_optimizations:
+        gc_collect_interval = 3.0
 
     while True:
         timeout = 1000.0


### PR DESCRIPTION
## Summary
- document how to run ComfyUI on Apple silicon with limited unified memory
- add `--mps-memory-optimizations` flag that automatically enables low memory options on macOS
- trigger faster garbage collection when this flag is used

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_685ec4fdcd74832289d69144ace07675